### PR TITLE
🛡️ Sentinel: [security improvement] Replace MD5 with SHA-256 and add nosec for validated SQL

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** The `MdBookManager.update_monthly_page` method concatenated external, potentially untrusted strings from PubMed (such as `paper.title`, `paper.journal`, `paper.pmid` and `paper.doi`) directly into HTML markup (`<a href="...">...</a>`) without escaping them. This exposed the application to Cross-Site Scripting (XSS).
 **Learning:** Any dynamic generation of HTML or Markdown that embeds external string data must consider XSS attacks, even if the data originates from a "trusted" external API like PubMed, because the content can still contain HTML-like syntax or malicious payloads.
 **Prevention:** Always use `html.escape()` or an equivalent context-aware escaping mechanism on external text fields before embedding them into HTML content.
+
+## 2026-05-11 - [Weak Hashing Algorithm in Cache Generation]
+**Vulnerability:** The cache key generation in `src/pubmed_miner/utils/cache.py` used `hashlib.md5()` which is a weak hash algorithm flagged by security linters (Bandit B324). Additionally, Bandit flagged a potential SQL injection (B608) on `f"SELECT * FROM {table}"` despite an explicit allowlist check.
+**Learning:** Using broken hashing algorithms like MD5 can lead to vulnerabilities or linter errors, even for non-cryptographic purposes like caching. For f-string SQL queries where parameterization isn't possible (e.g. table names) and validation is strictly enforced via an allowlist, linters will still flag it as a false positive unless explicitly suppressed.
+**Prevention:** Use `hashlib.sha256()` instead of `hashlib.md5()`. Explicitly suppress false-positive SQL injection linting errors using `# nosec B608` only after rigorous allowlist validation is implemented.

--- a/src/pubmed_miner/utils/cache.py
+++ b/src/pubmed_miner/utils/cache.py
@@ -816,7 +816,7 @@ def create_cache_key(prefix: str, *args: Any) -> str:
         if isinstance(arg, (dict, list)):
             # Create hash for complex objects
             key_parts.append(
-                hashlib.sha256(json.dumps(arg, sort_keys=True).encode()).hexdigest()[:8]
+                hashlib.sha256(json.dumps(arg, sort_keys=True).encode()).hexdigest()
             )
         else:
             key_parts.append(str(arg))

--- a/src/pubmed_miner/utils/cache.py
+++ b/src/pubmed_miner/utils/cache.py
@@ -639,7 +639,7 @@ class CacheManager:
                 for table in tables:
                     if table not in valid_tables:
                         raise ValueError(f"Invalid table name: {table}")
-                    cursor = conn.execute(f"SELECT * FROM {table}")
+                    cursor = conn.execute(f"SELECT * FROM {table}")  # nosec B608
                     rows = cursor.fetchall()
                     export_data[table] = [dict(row) for row in rows]
 
@@ -816,7 +816,7 @@ def create_cache_key(prefix: str, *args: Any) -> str:
         if isinstance(arg, (dict, list)):
             # Create hash for complex objects
             key_parts.append(
-                hashlib.md5(json.dumps(arg, sort_keys=True).encode()).hexdigest()[:8]
+                hashlib.sha256(json.dumps(arg, sort_keys=True).encode()).hexdigest()[:8]
             )
         else:
             key_parts.append(str(arg))


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Used weak cryptographic hash (MD5) and a false-positive SQL injection linting error.
🎯 Impact: Using MD5 raises linter warnings and is generally discouraged, while unsuppressed false positives crowd out real findings.
🔧 Fix: Upgraded to `hashlib.sha256` and appended `# nosec B608` to the validated SQL line.
✅ Verification: Ran `bandit -r src/pubmed_miner/utils/cache.py` to confirm zero issues found and ran `pytest tests/unit/test_cache_security.py` successfully.

---
*PR created automatically by Jules for task [5488334773727027279](https://jules.google.com/task/5488334773727027279) started by @partrita*